### PR TITLE
GIT-Banner naar rechterkant verplaatst.

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -35,7 +35,7 @@
     </div>
 </div>
 <div class="container">
-    <a href="https://github.com/WISVCH/chue"><img style="position: absolute; top: 50px; left: 0; border: 0;" src="https://camo.githubusercontent.com/8b6b8ccc6da3aa5722903da7b58eb5ab1081adee/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_orange_ff7600.png" /></a>
+    <a href="https://github.com/WISVCH/chue"><img style="position: absolute; top: 50px; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 
     <div class="hero-unit">
         <h1>CHue</h1>


### PR DESCRIPTION
Banner ging over content heen, waardoor je niet op de colorwheel kon klikken, omdat de href van de banner over de button heen viel. Is hierbij opgelost.
