### PR TITLE
Add alert function

### DIFF
--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -44,6 +44,13 @@ public class WebController {
         return "Random Colorloop";
     }
 
+    @RequestMapping("/alert")
+    @ResponseBody
+    String alert(@RequestParam(value="timeout", defaultValue = "5000") Integer timeout) {
+        hue.alert(timeout);
+        return String.format("Alerting for %d seconds", timeout);
+    }
+
 
     @RequestMapping({"/oranje", "/54"})
     @ResponseBody

--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -48,7 +48,7 @@ public class WebController {
     @ResponseBody
     String alert(@RequestParam(value="timeout", defaultValue = "5000") Integer timeout) {
         hue.alert(timeout);
-        return String.format("Alerting for %d seconds", timeout);
+        return String.format("Alerting for %d milliseconds", timeout);
     }
 
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -105,6 +105,14 @@
                         <p>Change single light color</p>
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <p><a href="#" th:href="@{alert}">alert</a></p>
+                    </td>
+                    <td>
+                        <p>Blink the lights. Time is set using the optional 'timeout' parameter, which defaults to 5000 milliseconds.</p>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
Blink the lights for a predefined amount of time. By default, Hue lights support an `alert` state of `lselect` (long select) which blinks for 30 seconds, or when stopped within that time range. Added a `timeout` parameter to make the alert function a bit more versatile, allowing you to manually stop the alert. 
