### PR TITLE
Adds tests for the most important endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,9 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-actuator")
     compile("org.webjars:bootstrap:3.2.0")
     compile("org.webjars:jquery:2.1.1")
+
     testCompile("junit:junit")
+    testCompile("org.springframework.boot:spring-boot-starter-test")
 }
 
 task wrapper(type: Wrapper) {

--- a/src/test/java/ch/wisv/chue/WebControllerTest.java
+++ b/src/test/java/ch/wisv/chue/WebControllerTest.java
@@ -5,9 +5,13 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class WebControllerTest {
     @Mock
@@ -16,36 +20,40 @@ public class WebControllerTest {
     @InjectMocks
     private WebController webController;
 
+    private MockMvc mockMvc;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(webController).build();
     }
 
     @Test
-    public void testColorHexAll() {
-        String response = webController.color("all", "ff0000");
-
-        assertThat(response, is("Changed colour of lamps (all) to #ff0000"));
+    public void testColorHexAll() throws Exception {
+        mockMvc.perform(get("/color/all/ff0000"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Changed colour of lamps (all) to #ff0000")));
     }
 
     @Test
-    public void testColorHexID() {
-        String response = webController.color("1", "0000ff");
-
-        assertThat(response, is("Changed colour of lamps (1) to #0000ff"));
+    public void testColorHexID() throws Exception {
+        mockMvc.perform(get("/color/1/0000ff"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Changed colour of lamps (1) to #0000ff")));
     }
 
     @Test
-    public void testColorFriendlyAll() {
-        String response = webController.colorFriendly("all", "red");
-
-        assertThat(response, is("Changed colour of lamps (all) to #ff0000"));
+    public void testColorFriendlyAll() throws Exception {
+        mockMvc.perform(get("/color/all/red"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Changed colour of lamps (all) to #ff0000")));
     }
 
     @Test
-    public void testColorFriendlyID() {
-        String response = webController.colorFriendly("2", "blue");
-
-        assertThat(response, is("Changed colour of lamps (2) to #0000ff"));
+    public void testColorFriendlyID() throws Exception {
+        mockMvc.perform(get("/color/2/blue"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Changed colour of lamps (2) to #0000ff")));
     }
 }

--- a/src/test/java/ch/wisv/chue/WebControllerTest.java
+++ b/src/test/java/ch/wisv/chue/WebControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,6 +28,28 @@ public class WebControllerTest {
         MockitoAnnotations.initMocks(this);
 
         mockMvc = MockMvcBuilders.standaloneSetup(webController).build();
+    }
+
+    @Test
+    public void testAlert() throws Exception {
+        mockMvc.perform(get("/alert"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Alerting for 5000 milliseconds")));
+    }
+
+    @Test
+    public void testAlertTimeOut() throws Exception {
+        mockMvc.perform(get("/alert")
+                .param("timeout", "100"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Alerting for 100 milliseconds")));
+    }
+
+    @Test
+    public void testOranje() throws Exception {
+        mockMvc.perform(get("/oranje"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("B'voranje")));
     }
 
     @Test
@@ -55,5 +78,14 @@ public class WebControllerTest {
         mockMvc.perform(get("/color/2/blue"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(is("Changed colour of lamps (2) to #0000ff")));
+    }
+
+    @Test
+    public void testColorPost() throws Exception {
+        mockMvc.perform((post("/color"))
+                .param("id[]", "1,2")
+                .param("hex", "#cc0000"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is("Changed colour of lamps ([1, 2]) to #cc0000")));
     }
 }

--- a/src/test/java/ch/wisv/chue/WebControllerTest.java
+++ b/src/test/java/ch/wisv/chue/WebControllerTest.java
@@ -1,0 +1,51 @@
+package ch.wisv.chue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WebControllerTest {
+    @Mock
+    private HueService hueService;
+
+    @InjectMocks
+    private WebController webController;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testColorHexAll() {
+        String response = webController.color("all", "ff0000");
+
+        assertThat(response, is("Changed colour of lamps (all) to #ff0000"));
+    }
+
+    @Test
+    public void testColorHexID() {
+        String response = webController.color("1", "0000ff");
+
+        assertThat(response, is("Changed colour of lamps (1) to #0000ff"));
+    }
+
+    @Test
+    public void testColorFriendlyAll() {
+        String response = webController.colorFriendly("all", "red");
+
+        assertThat(response, is("Changed colour of lamps (all) to #ff0000"));
+    }
+
+    @Test
+    public void testColorFriendlyID() {
+        String response = webController.colorFriendly("2", "blue");
+
+        assertThat(response, is("Changed colour of lamps (2) to #0000ff"));
+    }
+}


### PR DESCRIPTION
Before #15 is going to break stuff, let's add some tests for the currently most important API endpoints.

We can later on also verify interactions with the underlying mock(s), but as #15 is going to drastically change the infrastructure, let's for now assume that interactions with the lights actually happen and implement those verifications after #15 has been merged.
