### PR TITLE
Upgrade wisvch-bootstrap-theme and fix jsDelivr URls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-thymeleaf")
     compile("org.springframework.boot:spring-boot-starter-actuator")
 
-    compile("org.webjars.bower:wisvch-bootstrap-theme:0.0.2")
+    compile("org.webjars.bower:wisvch-bootstrap-theme:0.0.3")
     compile("org.webjars:jquery:2.1.4")
 
     testCompile("junit:junit")

--- a/src/main/resources/templates/fragments/alert.html
+++ b/src/main/resources/templates/fragments/alert.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link href="https://cdn.jsdelivr.net/webjars/wisvch-bootstrap-theme/dist/0.0.2/css/bootstrap.min.css"
-          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.2/dist/css/bootstrap.min.css}"
+    <link href="https://cdn.jsdelivr.net/webjars/org.webjars.bower/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css"
+          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen" />
     <script src="https://cdn.jsdelivr.net/webjars/jquery/2.1.4/jquery.min.js"
             th:src="@{/webjars/jquery/2.1.4/jquery.min.js}"></script>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link href="http://cdn.jsdelivr.net/webjars/wisvch-bootstrap-theme/0.0.2/dist/css/bootstrap.min.css"
-          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.2/dist/css/bootstrap.min.css}"
+    <link href="https://cdn.jsdelivr.net/webjars/org.webjars.bower/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css"
+          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen" />
 </head>
 <body>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -2,8 +2,8 @@
 <html>
 
 <head>
-    <link href="https://cdn.jsdelivr.net/webjars/wisvch-bootstrap-theme/dist/0.0.2/css/bootstrap.min.css"
-          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.2/dist/css/bootstrap.min.css}"
+    <link href="https://cdn.jsdelivr.net/webjars/org.webjars.bower/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css"
+          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen" />
     <script src="https://cdn.jsdelivr.net/webjars/jquery/2.1.4/jquery.min.js"
             th:src="@{/webjars/jquery/2.1.4/jquery.min.js}"></script>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,16 +4,16 @@
 <head>
     <title>CHue</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <link href="http://cdn.jsdelivr.net/webjars/wisvch-bootstrap-theme/0.0.2/dist/css/bootstrap.min.css"
-          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.2/dist/css/bootstrap.min.css}"
+    <link href="https://cdn.jsdelivr.net/webjars/org.webjars.bower/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css"
+          th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen" />
     <link href="../static/css/core.css"
           th:href="@{/css/core.css}"
           rel="stylesheet" media="screen" />
     <script src="https://cdn.jsdelivr.net/webjars/jquery/2.1.4/jquery.min.js"
             th:src="@{/webjars/jquery/2.1.4/jquery.min.js}"></script>
-    <script src="https://cdn.jsdelivr.net/webjars/wisvch-bootstrap-theme/dist/0.0.2/js/bootstrap.min.js"
-            th:src="@{/webjars/wisvch-bootstrap-theme/0.0.2/dist/js/bootstrap.min.js}"></script>
+    <script src="https://cdn.jsdelivr.net/webjars/org.webjars.bower/wisvch-bootstrap-theme/0.0.3/dist/js/bootstrap.min.js"
+            th:src="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/js/bootstrap.min.js}"></script>
 </head>
 <body>
 <!-- Header -->


### PR DESCRIPTION
So that we can open Thymeleaf templates in the browser directly \o/
