### PR TITLE
Fix internal server error when omitting lightIdentifier(s)

### DIFF
--- a/src/main/java/ch/wisv/chue/HueService.java
+++ b/src/main/java/ch/wisv/chue/HueService.java
@@ -116,7 +116,7 @@ public class HueService {
     };
 
     private String[] getLightIdentifiers(String... lightIdentifiers) {
-        if ("all".equals(lightIdentifiers[0])) {
+        if (lightIdentifiers.length == 0 || "all".equals(lightIdentifiers[0])) {
             List<PHLight> lights = getAllLights();
             String[] res = new String[lights.size()];
             for (int i = 0; i < lights.size(); i++) {


### PR DESCRIPTION
When omitting the identifier(s), the lightIdentifiers variable is an empty array.
Simple fix: if the array length equals 0, then use the default.

Fixes #23.
