### PR TITLE
Update to Spring Boot 1.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.2.7.RELEASE'
+        springBootVersion = '1.2.8.RELEASE'
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
http://spring.io/blog/2015/12/18/spring-boot-1-3-1-and-1-2-8-available-now
