### PR TITLE
Refactor String light identifiers to actual HueLamps

### DIFF
--- a/src/main/java/ch/wisv/chue/HueCommand.java
+++ b/src/main/java/ch/wisv/chue/HueCommand.java
@@ -1,10 +1,20 @@
 package ch.wisv.chue;
 
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
+
+import java.util.List;
 
 /**
  * Hue command interface
  */
 public interface HueCommand {
-    void execute(HueFacade hueFacade, String... lightIdentifiers);
+
+    /**
+     * Executes the command on the provided lamps via the provided facade.
+     *
+     * @param hueFacade the Hue facade
+     * @param lamps     the lamps
+     */
+    void execute(HueFacade hueFacade, List<HueLamp> lamps);
 }

--- a/src/main/java/ch/wisv/chue/HueCommand.java
+++ b/src/main/java/ch/wisv/chue/HueCommand.java
@@ -3,7 +3,7 @@ package ch.wisv.chue;
 import ch.wisv.chue.hue.HueFacade;
 import ch.wisv.chue.hue.HueLamp;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Hue command interface
@@ -14,7 +14,7 @@ public interface HueCommand {
      * Executes the command on the provided lamps via the provided facade.
      *
      * @param hueFacade the Hue facade
-     * @param lamps     the lamps
+     * @param lamps     the set of lamps
      */
-    void execute(HueFacade hueFacade, List<HueLamp> lamps);
+    void execute(HueFacade hueFacade, Set<HueLamp> lamps);
 }

--- a/src/main/java/ch/wisv/chue/HueService.java
+++ b/src/main/java/ch/wisv/chue/HueService.java
@@ -13,9 +13,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 @Service
@@ -110,8 +111,8 @@ public class HueService {
     /**
      * @return set with all Hue lamps
      */
-    public Set<HueLamp> getLamps() {
-        return new HashSet<>(hueFacade.getAvailableLamps().values());
+    public SortedSet<HueLamp> getLamps() {
+        return new TreeSet<>(hueFacade.getAvailableLamps().values());
     }
 
     /**

--- a/src/main/java/ch/wisv/chue/HueService.java
+++ b/src/main/java/ch/wisv/chue/HueService.java
@@ -13,9 +13,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,7 +38,7 @@ public class HueService {
      * @param state            the state to load
      * @param lamps the lamps to apply the state to
      */
-    public void loadState(HueState state, List<HueLamp> lamps) {
+    public void loadState(HueState state, Set<HueLamp> lamps) {
         if (!hueFacade.isBridgeAvailable()) {
             throw new StateNotLoadedException("Hue bridge is not available");
         }
@@ -61,7 +61,7 @@ public class HueService {
      * @param duration the time the event may take
      * @param lamps the lamps to apply the event to
      */
-    public void loadEvent(HueEvent event, int duration, List<HueLamp> lamps) {
+    public void loadEvent(HueEvent event, int duration, Set<HueLamp> lamps) {
         if (!hueFacade.isBridgeAvailable()) {
             throw new EventNotExecutedException("Hue bridge is not available");
         }
@@ -89,7 +89,7 @@ public class HueService {
      * @param millis duration in milliseconds
      * @param lamps the lamps to strobe
      */
-    public void strobe(int millis, List<HueLamp> lamps) {
+    public void strobe(int millis, Set<HueLamp> lamps) {
         try {
             hueFacade.strobe(millis, lamps);
         } catch (BridgeUnavailableException e) {
@@ -108,26 +108,22 @@ public class HueService {
     }
 
     /**
-     * @return list with all Hue lamps
+     * @return set with all Hue lamps
      */
-    public List<HueLamp> getLamps() {
-        return hueFacade.getAvailableLamps().entrySet().stream()
-                .map(Map.Entry::getValue)
-                .collect(Collectors.toList());
+    public Set<HueLamp> getLamps() {
+        return new HashSet<>(hueFacade.getAvailableLamps().values());
     }
 
     /**
      * Fetch multiple lamps using a list of identifiers
      *
      * @param ids the identifiers of the requested lamps
-     * @return the lamps
+     * @return the set of lamps
      */
-    public List<HueLamp> getLampsById(List<String> ids) {
-        List<HueLamp> lamps = new ArrayList<>();
-
-        ids.forEach(id -> lamps.add(hueFacade.getAvailableLamps().get(id)));
-
-        return lamps;
+    public Set<HueLamp> getLampsById(List<String> ids) {
+        return ids.stream()
+                .map(id -> hueFacade.getAvailableLamps().get(id))
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/ch/wisv/chue/HueService.java
+++ b/src/main/java/ch/wisv/chue/HueService.java
@@ -13,7 +13,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,52 +32,41 @@ public class HueService {
 
     private Command restoreState;
 
-    private String[] getLightIdentifiers(String... lightIdentifiers) {
-        if (lightIdentifiers.length == 0 || "all".equals(lightIdentifiers[0])) {
-            List<String> ids = hueFacade.getAvailableLamps().stream().map(HueLamp::getId).collect(Collectors.toList());
-            return ids.toArray(new String[ids.size()]);
-        } else {
-            return lightIdentifiers;
-        }
-    }
-
     /**
-     * Load a state on the lights
+     * Load a state on the lamps
      *
      * @param state            the state to load
-     * @param lightIdentifiers the lights to apply the state to
+     * @param lamps the lamps to apply the state to
      */
-    public void loadState(HueState state, String... lightIdentifiers) {
+    public void loadState(HueState state, List<HueLamp> lamps) {
         if (!hueFacade.isBridgeAvailable()) {
             throw new StateNotLoadedException("Hue bridge is not available");
         }
 
-        String[] ids = getLightIdentifiers(lightIdentifiers);
         restoreState = () -> {
-            new BlankState().execute(hueFacade, ids);
-            state.execute(hueFacade, ids);
+            new BlankState().execute(hueFacade, lamps);
+            state.execute(hueFacade, lamps);
             log.debug("Light states restored!");
         };
 
         // Set everything to default before loading state.
-        new BlankState().execute(hueFacade, ids);
-        state.execute(hueFacade, ids);
+        new BlankState().execute(hueFacade, lamps);
+        state.execute(hueFacade, lamps);
     }
 
     /**
-     * Load an event on the lights
+     * Load an event on the lamps
      *
      * @param event the event to load
      * @param duration the time the event may take
-     * @param lightIdentifiers the lights to apply the event to
+     * @param lamps the lamps to apply the event to
      */
-    public void loadEvent(HueEvent event, int duration, String... lightIdentifiers) {
+    public void loadEvent(HueEvent event, int duration, List<HueLamp> lamps) {
         if (!hueFacade.isBridgeAvailable()) {
             throw new EventNotExecutedException("Hue bridge is not available");
         }
 
-        String[] ids = getLightIdentifiers(lightIdentifiers);
-        event.execute(hueFacade, ids);
+        event.execute(hueFacade, lamps);
 
         Runnable restore = () -> {
             try {
@@ -87,36 +78,62 @@ public class HueService {
             if (this.restoreState != null)
                 this.restoreState.execute();
             else
-                new BlankState().execute(hueFacade, lightIdentifiers);
+                new BlankState().execute(hueFacade, lamps);
         };
         new Thread(restore, "ServiceThread").start();
     }
 
     /**
-     * Strobe the specified lights for the specified time
+     * Strobe the provided lamps for the specified time
      *
      * @param millis duration in milliseconds
-     * @param lightIdentifiers the lights to strobe
+     * @param lamps the lamps to strobe
      */
-    public void strobe(int millis, String... lightIdentifiers) {
+    public void strobe(int millis, List<HueLamp> lamps) {
         try {
-            hueFacade.strobe(millis, getLightIdentifiers(lightIdentifiers));
+            hueFacade.strobe(millis, lamps);
         } catch (BridgeUnavailableException e) {
             throw new EventNotExecutedException(e);
         }
     }
 
     /**
-     * @return list with all hue lamps
+     * Fetch a lamp by its identifier
+     *
+     * @param id the identifier
+     * @return the Hue lamp
      */
-    public List<HueLamp> getAvailableLamps() {
-        return hueFacade.getAvailableLamps();
+    public HueLamp getLampById(String id) {
+        return hueFacade.getAvailableLamps().get(id);
     }
 
     /**
-     * Set the hue facade to use (for testing purposes)
+     * @return list with all Hue lamps
+     */
+    public List<HueLamp> getLamps() {
+        return hueFacade.getAvailableLamps().entrySet().stream()
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Fetch multiple lamps using a list of identifiers
      *
-     * @param hueFacade the new hue facade
+     * @param ids the identifiers of the requested lamps
+     * @return the lamps
+     */
+    public List<HueLamp> getLampsById(List<String> ids) {
+        List<HueLamp> lamps = new ArrayList<>();
+
+        ids.forEach(id -> lamps.add(hueFacade.getAvailableLamps().get(id)));
+
+        return lamps;
+    }
+
+    /**
+     * Set the Hue facade to use (for testing purposes)
+     *
+     * @param hueFacade the new Hue facade
      */
     protected void setHueFacade(HueFacade hueFacade) {
         this.hueFacade = hueFacade;

--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Spring MVC Web Controller
@@ -49,7 +49,7 @@ public class WebController {
     String random() {
         StringBuilder sb = new StringBuilder("Randomization complete: ");
 
-        List<HueLamp> lamps = hue.getLamps();
+        Set<HueLamp> lamps = hue.getLamps();
         hue.loadState(new RandomColorState(), lamps);
 
         sb.append(getPrettyColors(lamps));
@@ -62,7 +62,7 @@ public class WebController {
         StringBuilder sb = new StringBuilder("Randomization complete: ");
 
         HueLamp lamp = hue.getLampById(id);
-        hue.loadState(new RandomColorState(), Collections.singletonList(lamp));
+        hue.loadState(new RandomColorState(), Collections.singleton(lamp));
 
         sb.append(getPrettyColor(lamp));
         return sb.toString();
@@ -93,7 +93,7 @@ public class WebController {
     @RequestMapping("/colorloop/{id}")
     @ResponseBody
     String colorLoop(@PathVariable String id) {
-        hue.loadState(new ColorLoopState(), Collections.singletonList(hue.getLampById(id)));
+        hue.loadState(new ColorLoopState(), Collections.singleton(hue.getLampById(id)));
         return "Colorloop";
     }
 
@@ -107,7 +107,7 @@ public class WebController {
     @RequestMapping("/randomcolorloop/{id}")
     @ResponseBody
     String randomColorLoop(@PathVariable String id) {
-        hue.loadState(new RandomColorLoopState(), Collections.singletonList(hue.getLampById(id)));
+        hue.loadState(new RandomColorLoopState(), Collections.singleton(hue.getLampById(id)));
         return "Random Colorloop";
     }
 
@@ -124,7 +124,7 @@ public class WebController {
         if ("all".equals(id)) {
             hue.loadEvent(new Alert(), timeout, hue.getLamps());
         } else {
-            hue.loadEvent(new Alert(), timeout, Collections.singletonList(hue.getLampById(id)));
+            hue.loadEvent(new Alert(), timeout, Collections.singleton(hue.getLampById(id)));
         }
 
         return String.format("Alerting for %d milliseconds", timeout);
@@ -142,11 +142,11 @@ public class WebController {
     String color(@PathVariable String id, @PathVariable String hex) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        List<HueLamp> lamps;
+        Set<HueLamp> lamps;
         if ("all".equals(id)) {
             lamps = hue.getLamps();
         } else {
-            lamps = Collections.singletonList(hue.getLampById(id));
+            lamps = Collections.singleton(hue.getLampById(id));
         }
 
         hue.loadState(new ColorState(Color.web('#' + hex)), lamps);
@@ -159,11 +159,11 @@ public class WebController {
     String colorFriendly(@PathVariable String id, @PathVariable String colorName) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        List<HueLamp> lamps;
+        Set<HueLamp> lamps;
         if ("all".equals(id)) {
             lamps = hue.getLamps();
         } else {
-            lamps = Collections.singletonList(hue.getLampById(id));
+            lamps = Collections.singleton(hue.getLampById(id));
         }
 
         hue.loadState(new ColorState(Color.valueOf(colorName)), lamps);
@@ -176,7 +176,7 @@ public class WebController {
     String colorPost(@RequestParam(value = "id[]") String[] ids, @RequestParam String hex) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        List<HueLamp> lamps = hue.getLampsById(Arrays.asList(ids));
+        Set<HueLamp> lamps = hue.getLampsById(Arrays.asList(ids));
         hue.loadState(new ColorState(Color.web(hex)), lamps);
 
         sb.append(getPrettyColors(lamps));
@@ -186,10 +186,10 @@ public class WebController {
     /**
      * Converts a list of lamps to a pretty String with identifiers and hex colors
      *
-     * @param lamps the list of lamps
+     * @param lamps the set of lamps
      * @return pretty String with identifiers and hex values of the colors of the lamps
      */
-    private static String getPrettyColors(List<HueLamp> lamps) {
+    private static String getPrettyColors(Set<HueLamp> lamps) {
         StringBuilder sb = new StringBuilder();
 
         lamps.stream().forEach(l -> sb.append(getPrettyColor(l)).append(", "));

--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -2,6 +2,7 @@ package ch.wisv.chue;
 
 import ch.wisv.chue.events.Alert;
 import ch.wisv.chue.events.EventNotExecutedException;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.states.*;
 import javafx.scene.paint.Color;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +12,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
-import java.util.Map;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Spring MVC Web Controller
@@ -38,32 +40,38 @@ public class WebController {
 
     @RequestMapping("/")
     String index(Model model) {
-        model.addAttribute("lights", hue.getAvailableLamps());
+        model.addAttribute("lights", hue.getLamps());
         return "index";
     }
 
     @RequestMapping("/random")
     @ResponseBody
     String random() {
-        RandomColorState randomColorState = new RandomColorState();
-        hue.loadState(randomColorState);
+        StringBuilder sb = new StringBuilder("Randomization complete: ");
 
-        return "Randomization complete: " + getPrettyLightColors(randomColorState.getLightColors());
+        List<HueLamp> lamps = hue.getLamps();
+        hue.loadState(new RandomColorState(), lamps);
+
+        sb.append(getPrettyColors(lamps));
+        return sb.toString();
     }
 
     @RequestMapping("/random/{id}")
     @ResponseBody
     String random(@PathVariable String id) {
-        RandomColorState randomColorState = new RandomColorState();
-        hue.loadState(randomColorState, id);
+        StringBuilder sb = new StringBuilder("Randomization complete: ");
 
-        return "Randomization complete: " + getPrettyLightColors(randomColorState.getLightColors());
+        HueLamp lamp = hue.getLampById(id);
+        hue.loadState(new RandomColorState(), Collections.singletonList(lamp));
+
+        sb.append(getPrettyColor(lamp));
+        return sb.toString();
     }
 
     @RequestMapping("/strobe/all")
     @ResponseBody
     String strobeAll(@RequestParam(value = "duration", defaultValue = "500") Integer duration) {
-        hue.strobe(duration);
+        hue.strobe(duration, hue.getLamps());
         return "Strobe for duration=" + duration + "ms";
     }
 
@@ -71,114 +79,144 @@ public class WebController {
     @ResponseBody
     String strobe(@RequestParam(value = "id[]") String[] id, @RequestParam(value = "duration", defaultValue = "500")
     Integer duration) {
-        hue.strobe(duration, id);
+        hue.strobe(duration, hue.getLampsById(Arrays.asList(id)));
         return "Strobe lamps (" + Arrays.asList(id) + ") for duration=" + duration + "ms";
     }
 
     @RequestMapping("/colorloop")
     @ResponseBody
     String colorLoop() {
-        hue.loadState(new ColorLoopState());
+        hue.loadState(new ColorLoopState(), hue.getLamps());
         return "Colorloop";
     }
 
     @RequestMapping("/colorloop/{id}")
     @ResponseBody
     String colorLoop(@PathVariable String id) {
-        hue.loadState(new ColorLoopState(), id);
+        hue.loadState(new ColorLoopState(), Collections.singletonList(hue.getLampById(id)));
         return "Colorloop";
     }
 
     @RequestMapping("/randomcolorloop")
     @ResponseBody
     String randomColorLoop() {
-        hue.loadState(new RandomColorLoopState());
+        hue.loadState(new RandomColorLoopState(), hue.getLamps());
         return "Random Colorloop";
     }
 
     @RequestMapping("/randomcolorloop/{id}")
     @ResponseBody
     String randomColorLoop(@PathVariable String id) {
-        hue.loadState(new RandomColorLoopState(), id);
+        hue.loadState(new RandomColorLoopState(), Collections.singletonList(hue.getLampById(id)));
         return "Random Colorloop";
     }
 
     @RequestMapping("/alert")
     @ResponseBody
     String alert(@RequestParam(value = "timeout", defaultValue = "5000") Integer timeout) {
-        hue.loadEvent(new Alert(), timeout);
+        hue.loadEvent(new Alert(), timeout, hue.getLamps());
         return String.format("Alerting for %d milliseconds", timeout);
     }
 
     @RequestMapping("/alert/{id}")
     @ResponseBody
     String alert(@RequestParam(value = "timeout", defaultValue = "5000") Integer timeout, @PathVariable String id) {
-        hue.loadEvent(new Alert(), timeout, id);
+        if ("all".equals(id)) {
+            hue.loadEvent(new Alert(), timeout, hue.getLamps());
+        } else {
+            hue.loadEvent(new Alert(), timeout, Collections.singletonList(hue.getLampById(id)));
+        }
+
         return String.format("Alerting for %d milliseconds", timeout);
     }
 
     @RequestMapping({"/oranje", "/54"})
     @ResponseBody
     String oranje() {
-        hue.loadState(new ColorState(Color.web("#FFA723")));
+        hue.loadState(new ColorState(Color.web("#FFA723")), hue.getLamps());
         return "B'voranje";
     }
 
     @RequestMapping(value = "/color/{id}/{hex:[a-fA-F0-9]{6}}", method = RequestMethod.GET)
     @ResponseBody
     String color(@PathVariable String id, @PathVariable String hex) {
-        ColorState colorState = new ColorState(Color.web('#' + hex));
-        hue.loadState(colorState, id);
+        StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        return "Time for some new colours: " + getPrettyLightColors(colorState.getLightColors());
+        List<HueLamp> lamps;
+        if ("all".equals(id)) {
+            lamps = hue.getLamps();
+        } else {
+            lamps = Collections.singletonList(hue.getLampById(id));
+        }
+
+        hue.loadState(new ColorState(Color.web('#' + hex)), lamps);
+        sb.append(getPrettyColors(lamps));
+        return sb.toString();
     }
 
     @RequestMapping(value = "/color/{id}/{colorName:(?![a-fA-F0-9]{6}).*}", method = RequestMethod.GET)
     @ResponseBody
     String colorFriendly(@PathVariable String id, @PathVariable String colorName) {
-        ColorState colorState = new ColorState(Color.valueOf(colorName));
-        hue.loadState(colorState, id);
+        StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        return "Time for some new colours: " + getPrettyLightColors(colorState.getLightColors());
+        List<HueLamp> lamps;
+        if ("all".equals(id)) {
+            lamps = hue.getLamps();
+        } else {
+            lamps = Collections.singletonList(hue.getLampById(id));
+        }
+
+        hue.loadState(new ColorState(Color.valueOf(colorName)), lamps);
+        sb.append(getPrettyColors(lamps));
+        return sb.toString();
     }
 
     @RequestMapping(value = "/color", method = RequestMethod.POST)
     @ResponseBody
-    String colorPost(@RequestParam(value = "id[]") String[] id, @RequestParam String hex) {
-        ColorState colorState = new ColorState(Color.web(hex));
-        hue.loadState(colorState, id);
+    String colorPost(@RequestParam(value = "id[]") String[] ids, @RequestParam String hex) {
+        StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        return "Time for some new colours: " + getPrettyLightColors(colorState.getLightColors());
+        List<HueLamp> lamps = hue.getLampsById(Arrays.asList(ids));
+        hue.loadState(new ColorState(Color.web(hex)), lamps);
+
+        sb.append(getPrettyColors(lamps));
+        return sb.toString();
     }
 
     /**
-     * Converts a map of lamps and their colors to a pretty String.
+     * Converts a list of lamps to a pretty String with identifiers and hex colors
      *
-     * @param affectedLights the map containing the affected lamps
-     * @return pretty String with hex values for all affected lamps
+     * @param lamps the list of lamps
+     * @return pretty String with identifiers and hex values of the colors of the lamps
      */
-    private static String getPrettyLightColors(Map<String, Color> affectedLights) {
-        if (affectedLights.size() == 0) {
-            return "no lights were changed";
-        }
-
+    private static String getPrettyColors(List<HueLamp> lamps) {
         StringBuilder sb = new StringBuilder();
 
-        for (Map.Entry<String, Color> light : affectedLights.entrySet()) {
-            sb.append("lamp ")
-                    .append(light.getKey())
-                    .append(" is now ")
-                    .append(String.format("#%02x%02x%02x",
-                            (int) Math.round(light.getValue().getRed() * 255.0),
-                            (int) Math.round(light.getValue().getGreen() * 255.0),
-                            (int) Math.round(light.getValue().getBlue() * 255.0)))
-                    .append(", ");
-        }
-
-        if (sb.length() > 1) {
-            sb.delete(sb.length() - 2, sb.length());
-        }
+        lamps.stream().forEach(l -> sb.append(getPrettyColor(l)).append(", "));
+        sb.delete(sb.length() - 2, sb.length());
 
         return sb.toString();
     }
+
+    /**
+     * Converts a lamps to a pretty String with identifier and hex color
+     *
+     * @param lamp the lamp
+     * @return pretty String with identifier and hex value of the color of the lamp
+     */
+    private static String getPrettyColor(HueLamp lamp) {
+        if (lamp == null || !lamp.getLastState().isPresent() || !lamp.getLastState().get().getColor().isPresent()) {
+            return "undefined lamp or colour";
+        }
+
+        Color c = lamp.getLastState().get().getColor().get();
+
+        return String.format("lamp %s is now #%02x%02x%02x",
+                lamp.getId(),
+                (int) Math.round(c.getRed() * 255.0),
+                (int) Math.round(c.getGreen() * 255.0),
+                (int) Math.round(c.getBlue() * 255.0));
+    }
+
+
 }

--- a/src/main/java/ch/wisv/chue/events/Alert.java
+++ b/src/main/java/ch/wisv/chue/events/Alert.java
@@ -5,7 +5,7 @@ import ch.wisv.chue.hue.HueFacade;
 import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Alert event
@@ -13,7 +13,7 @@ import java.util.List;
 public class Alert implements HueEvent {
 
     @Override
-    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+    public void execute(HueFacade hueFacade, Set<HueLamp> lamps) {
         for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setTransitionTime(0);

--- a/src/main/java/ch/wisv/chue/events/Alert.java
+++ b/src/main/java/ch/wisv/chue/events/Alert.java
@@ -2,21 +2,25 @@ package ch.wisv.chue.events;
 
 import ch.wisv.chue.hue.BridgeUnavailableException;
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
+
+import java.util.List;
 
 /**
  * Alert event
  */
 public class Alert implements HueEvent {
 
-    public void execute(HueFacade hueFacade, String... lightIdentifiers) {
-        for (String id : lightIdentifiers) {
+    @Override
+    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+        for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setTransitionTime(0);
             lightState.setAlertMode(HueLightState.AlertMode.LSELECT);
 
             try {
-                hueFacade.updateLightState(id, lightState);
+                hueFacade.updateLightState(lamp, lightState);
             } catch (BridgeUnavailableException e) {
                 throw new EventNotExecutedException(e);
             }

--- a/src/main/java/ch/wisv/chue/hue/HueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/HueFacade.java
@@ -1,7 +1,7 @@
 package ch.wisv.chue.hue;
 
-import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 
 public interface HueFacade {
     /**
@@ -19,7 +19,7 @@ public interface HueFacade {
     /**
      * @return map of all lamps, with identifiers pointing to the corresponding Hue lamp
      */
-    Map<String, HueLamp> getAvailableLamps();
+    SortedMap<String, HueLamp> getAvailableLamps();
 
     /**
      * @return true iff the bridge is available

--- a/src/main/java/ch/wisv/chue/hue/HueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/HueFacade.java
@@ -1,24 +1,25 @@
 package ch.wisv.chue.hue;
 
 import java.util.List;
+import java.util.Map;
 
 public interface HueFacade {
     /**
-     * Strobe the specified lights for the specified time.
+     * Strobe the provided lamps for the specified time.
      * Implemented on the facade because of the low-level operations.
      *
      * @param millis           duration in milliseconds
-     * @param lightIdentifiers the lights to strobe
+     * @param lamps the lamps to strobe
      * @see <a href="http://www.lmeijer.nl/archives/225-Do-hue-want-a-strobe-up-there.html">Strobe with Hue by Leon
      * Meijer</a>
      * @throws BridgeUnavailableException iff the bridge is not available
      */
-    void strobe(int millis, String... lightIdentifiers) throws BridgeUnavailableException;
+    void strobe(int millis, List<HueLamp> lamps) throws BridgeUnavailableException;
 
     /**
-     * @return list with String ids of all lights
+     * @return map of all lamps, with identifiers pointing to the corresponding Hue lamp
      */
-    List<HueLamp> getAvailableLamps();
+    Map<String, HueLamp> getAvailableLamps();
 
     /**
      * @return true iff the bridge is available
@@ -28,9 +29,9 @@ public interface HueFacade {
     /**
      * Sets the light state of the lamps
      *
-     * @param id the identifier of the light
+     * @param lamp the lamp that should be updated
      * @param lightState the new state
      * @throws BridgeUnavailableException iff the bridge is not available
      */
-    void updateLightState(String id, HueLightState lightState) throws BridgeUnavailableException;
+    void updateLightState(HueLamp lamp, HueLightState lightState) throws BridgeUnavailableException;
 }

--- a/src/main/java/ch/wisv/chue/hue/HueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/HueFacade.java
@@ -1,7 +1,7 @@
 package ch.wisv.chue.hue;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface HueFacade {
     /**
@@ -14,7 +14,7 @@ public interface HueFacade {
      * Meijer</a>
      * @throws BridgeUnavailableException iff the bridge is not available
      */
-    void strobe(int millis, List<HueLamp> lamps) throws BridgeUnavailableException;
+    void strobe(int millis, Set<HueLamp> lamps) throws BridgeUnavailableException;
 
     /**
      * @return map of all lamps, with identifiers pointing to the corresponding Hue lamp

--- a/src/main/java/ch/wisv/chue/hue/HueLamp.java
+++ b/src/main/java/ch/wisv/chue/hue/HueLamp.java
@@ -1,8 +1,11 @@
 package ch.wisv.chue.hue;
 
+import java.util.Optional;
+
 public class HueLamp {
     private String id;
     private String name;
+    private HueLightState lastState;
 
     public HueLamp(String id, String name) {
         this.id = id;
@@ -23,6 +26,14 @@ public class HueLamp {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Optional<HueLightState> getLastState() {
+        return Optional.ofNullable(lastState);
+    }
+
+    public void setLastState(HueLightState lastState) {
+        this.lastState = lastState;
     }
 
     @Override

--- a/src/main/java/ch/wisv/chue/hue/HueLamp.java
+++ b/src/main/java/ch/wisv/chue/hue/HueLamp.java
@@ -2,7 +2,7 @@ package ch.wisv.chue.hue;
 
 import java.util.Optional;
 
-public class HueLamp {
+public class HueLamp implements Comparable<HueLamp> {
     private String id;
     private String name;
     private HueLightState lastState;
@@ -52,5 +52,10 @@ public class HueLamp {
         int result = id.hashCode();
         result = 31 * result + (name != null ? name.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public int compareTo(HueLamp o) {
+        return id.compareTo(o.getId());
     }
 }

--- a/src/main/java/ch/wisv/chue/hue/LoggingHueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/LoggingHueFacade.java
@@ -5,8 +5,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class LoggingHueFacade implements HueFacade {
     private static final Logger log = LoggerFactory.getLogger(LoggingHueFacade.class);
@@ -20,7 +20,7 @@ public class LoggingHueFacade implements HueFacade {
     }
 
     @Override
-    public void strobe(int millis, List<HueLamp> lamps) throws BridgeUnavailableException {
+    public void strobe(int millis, Set<HueLamp> lamps) throws BridgeUnavailableException {
         log.info("Strobing " + lamps + " for " + millis + " ms.");
     }
 

--- a/src/main/java/ch/wisv/chue/hue/LoggingHueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/LoggingHueFacade.java
@@ -4,14 +4,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class LoggingHueFacade implements HueFacade {
     private static final Logger log = LoggerFactory.getLogger(LoggingHueFacade.class);
 
-    private Map<String, HueLamp> lamps = new HashMap<>();
+    private SortedMap<String, HueLamp> lamps = new TreeMap<>();
 
     @PostConstruct
     public void init() {
@@ -25,7 +25,7 @@ public class LoggingHueFacade implements HueFacade {
     }
 
     @Override
-    public Map<String, HueLamp> getAvailableLamps() {
+    public SortedMap<String, HueLamp> getAvailableLamps() {
         return lamps;
     }
 

--- a/src/main/java/ch/wisv/chue/hue/LoggingHueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/LoggingHueFacade.java
@@ -3,20 +3,30 @@ package ch.wisv.chue.hue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class LoggingHueFacade implements HueFacade {
     private static final Logger log = LoggerFactory.getLogger(LoggingHueFacade.class);
 
-    @Override
-    public void strobe(int millis, String... lightIdentifiers) {
-        log.info("Strobing " + Arrays.asList(lightIdentifiers) + " for " + millis + " ms.");
+    private Map<String, HueLamp> lamps = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        lamps.put("1", new HueLamp("1", "Dummy 1"));
+        lamps.put("2", new HueLamp("2", "Dummy 2"));
     }
 
     @Override
-    public List<HueLamp> getAvailableLamps() {
-        return Arrays.asList(new HueLamp("1", "Dummy 1"), new HueLamp("2", "Dummy 2"));
+    public void strobe(int millis, List<HueLamp> lamps) throws BridgeUnavailableException {
+        log.info("Strobing " + lamps + " for " + millis + " ms.");
+    }
+
+    @Override
+    public Map<String, HueLamp> getAvailableLamps() {
+        return lamps;
     }
 
     @Override
@@ -26,7 +36,13 @@ public class LoggingHueFacade implements HueFacade {
     }
 
     @Override
-    public void updateLightState(String id, HueLightState lightState) {
-        log.info("Updating " + id + " to " + lightState);
+    public void updateLightState(HueLamp lamp, HueLightState lightState) throws BridgeUnavailableException {
+        if (null == lamp) {
+            log.warn("The lamp is null!");
+            return;
+        }
+
+        log.info("Updating " + lamp + " to " + lightState);
+        lamp.setLastState(lightState);
     }
 }

--- a/src/main/java/ch/wisv/chue/hue/PhilipsHueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/PhilipsHueFacade.java
@@ -15,10 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
 import javax.annotation.PostConstruct;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class PhilipsHueFacade implements HueFacade {
 
@@ -33,7 +30,7 @@ public class PhilipsHueFacade implements HueFacade {
 
     private PHBridge bridge;
 
-    private Map<String, HueLamp> lamps = new HashMap<>();
+    private SortedMap<String, HueLamp> lamps = new TreeMap<>();
 
     /**
      * Connect to the last known access point.
@@ -56,7 +53,7 @@ public class PhilipsHueFacade implements HueFacade {
     private PHSDKListener listener = new PHSDKListener() {
 
         private void updateLampMap() {
-            Map<String, HueLamp> newLamps = new HashMap<>();
+            SortedMap<String, HueLamp> newLamps = new TreeMap<>();
 
             for (PHLight lamp : bridge.getResourceCache().getAllLights()) {
                 if (lamps.containsKey(lamp.getIdentifier())) {
@@ -167,9 +164,9 @@ public class PhilipsHueFacade implements HueFacade {
     }
 
     @Override
-    public Map<String, HueLamp> getAvailableLamps() {
+    public SortedMap<String, HueLamp> getAvailableLamps() {
         if (!isBridgeAvailable()) {
-            return new HashMap<>();
+            return Collections.emptySortedMap();
         }
 
         return lamps;

--- a/src/main/java/ch/wisv/chue/hue/PhilipsHueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/PhilipsHueFacade.java
@@ -18,6 +18,7 @@ import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class PhilipsHueFacade implements HueFacade {
 
@@ -130,7 +131,7 @@ public class PhilipsHueFacade implements HueFacade {
     };
 
     @Override
-    public void strobe(int millis, List<HueLamp> lamps) throws BridgeUnavailableException {
+    public void strobe(int millis, Set<HueLamp> lamps) throws BridgeUnavailableException {
         if (!isBridgeAvailable()) {
             log.warn("Strobe failed: bridge not available!");
             throw new BridgeUnavailableException();

--- a/src/main/java/ch/wisv/chue/states/BlankState.java
+++ b/src/main/java/ch/wisv/chue/states/BlankState.java
@@ -5,7 +5,7 @@ import ch.wisv.chue.hue.HueFacade;
 import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Blank state
@@ -13,7 +13,7 @@ import java.util.List;
 public class BlankState implements HueState {
 
     @Override
-    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+    public void execute(HueFacade hueFacade, Set<HueLamp> lamps) {
         for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setEffectMode(HueLightState.EffectMode.NONE);

--- a/src/main/java/ch/wisv/chue/states/BlankState.java
+++ b/src/main/java/ch/wisv/chue/states/BlankState.java
@@ -2,7 +2,10 @@ package ch.wisv.chue.states;
 
 import ch.wisv.chue.hue.BridgeUnavailableException;
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
+
+import java.util.List;
 
 /**
  * Blank state
@@ -10,15 +13,15 @@ import ch.wisv.chue.hue.HueLightState;
 public class BlankState implements HueState {
 
     @Override
-    public void execute(HueFacade hueFacade, String... lightIdentifiers) {
-        for (String id : lightIdentifiers) {
+    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+        for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setEffectMode(HueLightState.EffectMode.NONE);
             lightState.setAlertMode(HueLightState.AlertMode.NONE);
             lightState.setTransitionTime(400);
 
             try {
-                hueFacade.updateLightState(id, lightState);
+                hueFacade.updateLightState(lamp, lightState);
             } catch (BridgeUnavailableException e) {
                 throw new StateNotLoadedException(e);
             }

--- a/src/main/java/ch/wisv/chue/states/ColorLoopState.java
+++ b/src/main/java/ch/wisv/chue/states/ColorLoopState.java
@@ -5,7 +5,7 @@ import ch.wisv.chue.hue.HueFacade;
 import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Color loop state
@@ -13,7 +13,7 @@ import java.util.List;
 public class ColorLoopState implements HueState {
 
     @Override
-    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+    public void execute(HueFacade hueFacade, Set<HueLamp> lamps) {
         for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setEffectMode(HueLightState.EffectMode.COLORLOOP);

--- a/src/main/java/ch/wisv/chue/states/ColorLoopState.java
+++ b/src/main/java/ch/wisv/chue/states/ColorLoopState.java
@@ -2,20 +2,24 @@ package ch.wisv.chue.states;
 
 import ch.wisv.chue.hue.BridgeUnavailableException;
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
+
+import java.util.List;
 
 /**
  * Color loop state
  */
 public class ColorLoopState implements HueState {
+
     @Override
-    public void execute(HueFacade hueFacade, String... lightIdentifiers) {
-        for (String lightId : lightIdentifiers) {
+    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+        for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setEffectMode(HueLightState.EffectMode.COLORLOOP);
 
             try {
-                hueFacade.updateLightState(lightId, lightState);
+                hueFacade.updateLightState(lamp, lightState);
             } catch (BridgeUnavailableException e) {
                 throw new StateNotLoadedException(e);
             }

--- a/src/main/java/ch/wisv/chue/states/ColorState.java
+++ b/src/main/java/ch/wisv/chue/states/ColorState.java
@@ -2,11 +2,11 @@ package ch.wisv.chue.states;
 
 import ch.wisv.chue.hue.BridgeUnavailableException;
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 import javafx.scene.paint.Color;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 /**
  * Color state
@@ -15,29 +15,21 @@ public class ColorState implements HueState {
 
     private Color color;
 
-    private Map<String, Color> lightColors = new HashMap<>();
-
     public ColorState(Color color) {
         this.color = color;
     }
 
-    public Map<String, Color> getLightColors() {
-        return lightColors;
-    }
-
     @Override
-    public void execute(HueFacade hueFacade, String... lightIdentifiers) {
-        for (String id : lightIdentifiers) {
+    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+        for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setColor(color);
 
             try {
-                hueFacade.updateLightState(id, lightState);
+                hueFacade.updateLightState(lamp, lightState);
             } catch (BridgeUnavailableException e) {
                 throw new StateNotLoadedException(e);
             }
-
-            lightColors.put(id, color);
         }
     }
 }

--- a/src/main/java/ch/wisv/chue/states/ColorState.java
+++ b/src/main/java/ch/wisv/chue/states/ColorState.java
@@ -6,7 +6,7 @@ import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 import javafx.scene.paint.Color;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Color state
@@ -20,7 +20,7 @@ public class ColorState implements HueState {
     }
 
     @Override
-    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+    public void execute(HueFacade hueFacade, Set<HueLamp> lamps) {
         for (HueLamp lamp : lamps) {
             HueLightState lightState = new HueLightState();
             lightState.setColor(color);

--- a/src/main/java/ch/wisv/chue/states/RandomColorLoopState.java
+++ b/src/main/java/ch/wisv/chue/states/RandomColorLoopState.java
@@ -2,20 +2,23 @@ package ch.wisv.chue.states;
 
 import ch.wisv.chue.hue.BridgeUnavailableException;
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 import javafx.scene.paint.Color;
 
+import java.util.List;
 import java.util.Random;
 
 /**
  * Random color loop state
  */
 public class RandomColorLoopState implements HueState {
+
     @Override
-    public void execute(HueFacade hueFacade, String... lightIdentifiers) {
+    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
         Random rand = new Random();
 
-        for (String lightId : lightIdentifiers) {
+        for (HueLamp lamp : lamps) {
             Color color = Color.hsb(rand.nextDouble() * 360, 1, 1);
 
             HueLightState lightState = new HueLightState();
@@ -23,7 +26,7 @@ public class RandomColorLoopState implements HueState {
             lightState.setColor(color);
 
             try {
-                hueFacade.updateLightState(lightId, lightState);
+                hueFacade.updateLightState(lamp, lightState);
             } catch (BridgeUnavailableException e) {
                 throw new StateNotLoadedException(e);
             }

--- a/src/main/java/ch/wisv/chue/states/RandomColorLoopState.java
+++ b/src/main/java/ch/wisv/chue/states/RandomColorLoopState.java
@@ -6,8 +6,8 @@ import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 import javafx.scene.paint.Color;
 
-import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * Random color loop state
@@ -15,7 +15,7 @@ import java.util.Random;
 public class RandomColorLoopState implements HueState {
 
     @Override
-    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+    public void execute(HueFacade hueFacade, Set<HueLamp> lamps) {
         Random rand = new Random();
 
         for (HueLamp lamp : lamps) {

--- a/src/main/java/ch/wisv/chue/states/RandomColorState.java
+++ b/src/main/java/ch/wisv/chue/states/RandomColorState.java
@@ -2,11 +2,11 @@ package ch.wisv.chue.states;
 
 import ch.wisv.chue.hue.BridgeUnavailableException;
 import ch.wisv.chue.hue.HueFacade;
+import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 import javafx.scene.paint.Color;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -14,29 +14,21 @@ import java.util.Random;
  */
 public class RandomColorState implements HueState {
 
-    private Map<String, Color> lightColors = new HashMap<>();
-
-    public Map<String, Color> getLightColors() {
-        return lightColors;
-    }
-
     @Override
-    public void execute(HueFacade hueFacade, String... lightIdentifiers) {
+    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
         Random rand = new Random();
 
-        for (String id : lightIdentifiers) {
+        for (HueLamp lamp : lamps) {
             Color color = Color.hsb(rand.nextDouble() * 360, 1, 1);
 
             HueLightState lightState = new HueLightState();
             lightState.setColor(color);
 
             try {
-                hueFacade.updateLightState(id, lightState);
+                hueFacade.updateLightState(lamp, lightState);
             } catch (BridgeUnavailableException e) {
                 throw new StateNotLoadedException(e);
             }
-
-            lightColors.put(id, color);
         }
     }
 }

--- a/src/main/java/ch/wisv/chue/states/RandomColorState.java
+++ b/src/main/java/ch/wisv/chue/states/RandomColorState.java
@@ -6,8 +6,8 @@ import ch.wisv.chue.hue.HueLamp;
 import ch.wisv.chue.hue.HueLightState;
 import javafx.scene.paint.Color;
 
-import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * Random color loop state
@@ -15,7 +15,7 @@ import java.util.Random;
 public class RandomColorState implements HueState {
 
     @Override
-    public void execute(HueFacade hueFacade, List<HueLamp> lamps) {
+    public void execute(HueFacade hueFacade, Set<HueLamp> lamps) {
         Random rand = new Random();
 
         for (HueLamp lamp : lamps) {

--- a/src/test/java/ch/wisv/chue/WebControllerTest.java
+++ b/src/test/java/ch/wisv/chue/WebControllerTest.java
@@ -12,8 +12,9 @@ import org.mockito.Spy;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Matchers.anyInt;
@@ -40,7 +41,7 @@ public class WebControllerTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        Map<String, HueLamp> lamps = new HashMap<>();
+        SortedMap<String, HueLamp> lamps = new TreeMap<>();
         lamps.put("1", new HueLamp("1", "Lamp 1"));
         lamps.put("2", new HueLamp("2", "Lamp 2"));
         lamps.put("3", new HueLamp("3", "Lamp 3"));
@@ -55,7 +56,7 @@ public class WebControllerTest {
     @Test
     public void testEventFailBridgeUnavailable() throws Exception {
         when(hueFacade.isBridgeAvailable()).thenReturn(false);
-        when(hueFacade.getAvailableLamps()).thenReturn(new HashMap<>());
+        when(hueFacade.getAvailableLamps()).thenReturn(Collections.emptySortedMap());
 
         mockMvc.perform(get("/alert"))
                 .andExpect(status().isServiceUnavailable())
@@ -66,7 +67,7 @@ public class WebControllerTest {
     @Test
     public void testEventFailBridgeUnavailableStrobe() throws Exception {
         when(hueFacade.isBridgeAvailable()).thenReturn(false);
-        when(hueFacade.getAvailableLamps()).thenReturn(new HashMap<>());
+        when(hueFacade.getAvailableLamps()).thenReturn(Collections.emptySortedMap());
         doThrow(new BridgeUnavailableException()).when(hueFacade).strobe(anyInt(), anyVararg());
 
         mockMvc.perform(get("/strobe/all"))
@@ -77,7 +78,7 @@ public class WebControllerTest {
     @Test
     public void testStateFailBridgeUnavailable() throws Exception {
         when(hueFacade.isBridgeAvailable()).thenReturn(false);
-        when(hueFacade.getAvailableLamps()).thenReturn(new HashMap<>());
+        when(hueFacade.getAvailableLamps()).thenReturn(Collections.emptySortedMap());
 
         mockMvc.perform(get("/random"))
                 .andExpect(status().isServiceUnavailable())


### PR DESCRIPTION
With #3 in mind:
- Add methods for maintaining the current set of lamps
- Add methods for getting lamp(s) by identifier
- Move "all" identifier handling to the web controller (_should we maybe deprecate this?_)
- Update test suite accordingly

Not yet tested on actual lamps using the Philips Hue facade.
