### PR TITLE
Drop support for `all` identifier

### DIFF
--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -68,14 +68,14 @@ public class WebController {
         return sb.toString();
     }
 
-    @RequestMapping("/strobe/all")
+    @RequestMapping(value = "/strobe", method = RequestMethod.GET)
     @ResponseBody
     String strobeAll(@RequestParam(value = "duration", defaultValue = "500") Integer duration) {
         hue.strobe(duration, hue.getLamps());
         return "Strobe for duration=" + duration + "ms";
     }
 
-    @RequestMapping("/strobe")
+    @RequestMapping(value = "/strobe", method = RequestMethod.POST)
     @ResponseBody
     String strobe(@RequestParam(value = "id[]") String[] id, @RequestParam(value = "duration", defaultValue = "500")
     Integer duration) {
@@ -121,12 +121,7 @@ public class WebController {
     @RequestMapping("/alert/{id}")
     @ResponseBody
     String alert(@RequestParam(value = "timeout", defaultValue = "5000") Integer timeout, @PathVariable String id) {
-        if ("all".equals(id)) {
-            hue.loadEvent(new Alert(), timeout, hue.getLamps());
-        } else {
-            hue.loadEvent(new Alert(), timeout, Collections.singleton(hue.getLampById(id)));
-        }
-
+        hue.loadEvent(new Alert(), timeout, Collections.singleton(hue.getLampById(id)));
         return String.format("Alerting for %d milliseconds", timeout);
     }
 
@@ -142,14 +137,21 @@ public class WebController {
     String color(@PathVariable String id, @PathVariable String hex) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        Set<HueLamp> lamps;
-        if ("all".equals(id)) {
-            lamps = hue.getLamps();
-        } else {
-            lamps = Collections.singleton(hue.getLampById(id));
-        }
-
+        Set<HueLamp> lamps = Collections.singleton(hue.getLampById(id));
         hue.loadState(new ColorState(Color.web('#' + hex)), lamps);
+
+        sb.append(getPrettyColors(lamps));
+        return sb.toString();
+    }
+
+    @RequestMapping(value = "/color/{hex:[a-fA-F0-9]{6}}", method = RequestMethod.GET)
+    @ResponseBody
+    String color(@PathVariable String hex) {
+        StringBuilder sb = new StringBuilder("Time for some new colours: ");
+
+        Set<HueLamp> lamps = hue.getLamps();
+        hue.loadState(new ColorState(Color.web('#' + hex)), lamps);
+
         sb.append(getPrettyColors(lamps));
         return sb.toString();
     }
@@ -159,14 +161,21 @@ public class WebController {
     String colorFriendly(@PathVariable String id, @PathVariable String colorName) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");
 
-        Set<HueLamp> lamps;
-        if ("all".equals(id)) {
-            lamps = hue.getLamps();
-        } else {
-            lamps = Collections.singleton(hue.getLampById(id));
-        }
-
+        Set<HueLamp> lamps = Collections.singleton(hue.getLampById(id));
         hue.loadState(new ColorState(Color.valueOf(colorName)), lamps);
+
+        sb.append(getPrettyColors(lamps));
+        return sb.toString();
+    }
+
+    @RequestMapping(value = "/color/{colorName:(?![a-fA-F0-9]{6}).*}", method = RequestMethod.GET)
+    @ResponseBody
+    String colorFriendly(@PathVariable String colorName) {
+        StringBuilder sb = new StringBuilder("Time for some new colours: ");
+
+        Set<HueLamp> lamps = hue.getLamps();
+        hue.loadState(new ColorState(Color.valueOf(colorName)), lamps);
+
         sb.append(getPrettyColors(lamps));
         return sb.toString();
     }

--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -132,7 +132,7 @@ public class WebController {
         return "B'voranje";
     }
 
-    @RequestMapping(value = "/color/{id}/{hex:[a-fA-F0-9]{6}}", method = RequestMethod.GET)
+    @RequestMapping(value = "/color/{hex:[a-fA-F0-9]{6}}/{id}", method = RequestMethod.GET)
     @ResponseBody
     String color(@PathVariable String id, @PathVariable String hex) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");
@@ -156,7 +156,7 @@ public class WebController {
         return sb.toString();
     }
 
-    @RequestMapping(value = "/color/{id}/{colorName:(?![a-fA-F0-9]{6}).*}", method = RequestMethod.GET)
+    @RequestMapping(value = "/color/{colorName:(?![a-fA-F0-9]{6}).*}/{id}", method = RequestMethod.GET)
     @ResponseBody
     String colorFriendly(@PathVariable String id, @PathVariable String colorName) {
         StringBuilder sb = new StringBuilder("Time for some new colours: ");

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -59,6 +59,8 @@
     </div>
     <div>
         <h1>Endpoints</h1>
+        <p>In the table below, the identifier {id} can always be omitted to apply the desired event/state on all
+            lamps.</p>
         <table>
             <thead>
                 <tr>
@@ -77,15 +79,15 @@
                 </tr>
                 <tr>
                     <td>
-                        <p><a href="#" th:href="@{random/all}">random/{id}</a></p>
+                        <p><a href="#" th:href="@{random}">random/{id}</a></p>
                     </td>
                     <td>
-                        <p>Random</p>
+                        <p>Random color</p>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <p><a href="#" th:href="@{colorloop/all}">colorloop/{id}</a></p>
+                        <p><a href="#" th:href="@{colorloop}">colorloop/{id}</a></p>
                     </td>
                     <td>
                         <p>Continuous color loop</p>
@@ -93,34 +95,29 @@
                 </tr>
                 <tr>
                     <td>
-                        <p>/color/all/{hex}</p>
+                        <p>color/{id}/{value}</p>
                     </td>
                     <td>
-                        <p>Change all light colors</p>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <p>/color/{id}/{hex}</p>
-                    </td>
-                    <td>
-                        <p>Change single light color</p>
+                        <p>Set lamp color. The color value can be specified as name (e.g. 'red') or as hex (e.g.
+                            'ff0000').</p>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <p><a href="#" th:href="@{alert/all}">alert/{id}</a></p>
+                        <p><a href="#" th:href="@{alert}">alert/{id}</a></p>
                     </td>
                     <td>
-                        <p>Blink the lights. Time is set using the optional 'timeout' parameter, which defaults to 5000 milliseconds.</p>
+                        <p>Blink the lamps. Time is set using the optional 'timeout' parameter, which defaults to 5000
+                            milliseconds.</p>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <p><a href="#" th:href="@{strobe/all}">strobe/all</a></p>
+                        <p><a href="#" th:href="@{strobe}">strobe</a></p>
                     </td>
                     <td>
-                        <p>Strobe the lights. Duration is set using the optional 'duration' parameter, which defaults to 500 milliseconds. Without 'all' in the path you can specify which lamps to strobe using the 'id[]' parameter.</p>
+                        <p>Strobe the lights. Duration is set using the optional 'duration' parameter, which defaults to
+                            500 milliseconds. You can specify the lamps by posting the 'id[]' parameter.</p>
                     </td>
                 </tr>
             </tbody>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -95,7 +95,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <p>color/{id}/{value}</p>
+                        <p>color/{value}/{id}</p>
                     </td>
                     <td>
                         <p>Set lamp color. The color value can be specified as name (e.g. 'red') or as hex (e.g.

--- a/src/test/java/ch/wisv/chue/WebControllerTest.java
+++ b/src/test/java/ch/wisv/chue/WebControllerTest.java
@@ -124,7 +124,7 @@ public class WebControllerTest {
 
     @Test
     public void testColorHexID() throws Exception {
-        mockMvc.perform(get("/color/1/0000ff"))
+        mockMvc.perform(get("/color/0000ff/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         is("Time for some new colours: lamp 1 is now #0000ff")));
@@ -140,7 +140,7 @@ public class WebControllerTest {
 
     @Test
     public void testColorFriendlyID() throws Exception {
-        mockMvc.perform(get("/color/2/blue"))
+        mockMvc.perform(get("/color/blue/2"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         is("Time for some new colours: lamp 2 is now #0000ff")));

--- a/src/test/java/ch/wisv/chue/WebControllerTest.java
+++ b/src/test/java/ch/wisv/chue/WebControllerTest.java
@@ -70,7 +70,7 @@ public class WebControllerTest {
         when(hueFacade.getAvailableLamps()).thenReturn(Collections.emptySortedMap());
         doThrow(new BridgeUnavailableException()).when(hueFacade).strobe(anyInt(), anyVararg());
 
-        mockMvc.perform(get("/strobe/all"))
+        mockMvc.perform(get("/strobe"))
                 .andExpect(status().isServiceUnavailable())
                 .andExpect(content().string(is("The event was not executed: Hue bridge is not available")));
     }
@@ -87,7 +87,7 @@ public class WebControllerTest {
 
     @Test
     public void testAlertAll() throws Exception {
-        mockMvc.perform(get("/alert/all"))
+        mockMvc.perform(get("/alert"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(is("Alerting for 5000 milliseconds")));
     }
@@ -101,7 +101,7 @@ public class WebControllerTest {
 
     @Test
     public void testAlertAllTimeOut() throws Exception {
-        mockMvc.perform(get("/alert/all")
+        mockMvc.perform(get("/alert")
                 .param("timeout", "100"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(is("Alerting for 100 milliseconds")));
@@ -116,7 +116,7 @@ public class WebControllerTest {
 
     @Test
     public void testColorHexAll() throws Exception {
-        mockMvc.perform(get("/color/all/ff0000"))
+        mockMvc.perform(get("/color/ff0000"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         is("Time for some new colours: lamp 1 is now #ff0000, lamp 2 is now #ff0000, lamp 3 is now #ff0000")));
@@ -132,7 +132,7 @@ public class WebControllerTest {
 
     @Test
     public void testColorFriendlyAll() throws Exception {
-        mockMvc.perform(get("/color/all/red"))
+        mockMvc.perform(get("/color/red"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         is("Time for some new colours: lamp 1 is now #ff0000, lamp 2 is now #ff0000, lamp 3 is now #ff0000")));


### PR DESCRIPTION
Completely remove the `all` identifier from the API. Calls affecting all lamps should simply omit the identifier.
