### PR TITLE
Add current color of lamps to web interface

### DIFF
--- a/src/main/java/ch/wisv/chue/WebController.java
+++ b/src/main/java/ch/wisv/chue/WebController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Spring MVC Web Controller
@@ -40,7 +42,17 @@ public class WebController {
 
     @RequestMapping("/")
     String index(Model model) {
-        model.addAttribute("lights", hue.getLamps());
+        model.addAttribute("lights",
+                new TreeMap<>(hue.getLamps().stream()
+                        .collect(Collectors.toMap(
+                                l -> l,
+                                l -> colorToString(
+                                        l.getLastState().isPresent()
+                                                ? l.getLastState().get().getColor().orElse(Color.LIGHTGRAY)
+                                                : Color.LIGHTGRAY
+                                )
+                        )))
+        );
         return "index";
     }
 
@@ -203,14 +215,21 @@ public class WebController {
             return "undefined lamp or colour";
         }
 
-        Color c = lamp.getLastState().get().getColor().get();
-
-        return String.format("lamp %s is now #%02x%02x%02x",
+        return String.format("lamp %s is now %s",
                 lamp.getId(),
+                colorToString(lamp.getLastState().get().getColor().get()));
+    }
+
+    /**
+     * Convert a Java FX Color to a hexadecimal representation as String
+     *
+     * @param c the color
+     * @return the hex value of the color
+     */
+    private static String colorToString(Color c) {
+        return String.format("#%02x%02x%02x",
                 (int) Math.round(c.getRed() * 255.0),
                 (int) Math.round(c.getGreen() * 255.0),
                 (int) Math.round(c.getBlue() * 255.0));
     }
-
-
 }

--- a/src/main/java/ch/wisv/chue/hue/HueLightState.java
+++ b/src/main/java/ch/wisv/chue/hue/HueLightState.java
@@ -3,44 +3,43 @@ package ch.wisv.chue.hue;
 import javafx.scene.paint.Color;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 
 public class HueLightState {
-    private Optional<AlertMode> alertMode = Optional.empty();
-    private Optional<EffectMode> effectMode = Optional.empty();
-    private OptionalInt transitionTime = OptionalInt.empty();
-    private Optional<Color> color = Optional.empty();
+    private AlertMode alertMode;
+    private EffectMode effectMode;
+    private Integer transitionTime;
+    private Color color;
 
     public Optional<AlertMode> getAlertMode() {
-        return alertMode;
+        return Optional.ofNullable(alertMode);
     }
 
     public void setAlertMode(AlertMode alertMode) {
-        this.alertMode = Optional.of(alertMode);
+        this.alertMode = alertMode;
     }
 
     public Optional<EffectMode> getEffectMode() {
-        return effectMode;
+        return Optional.ofNullable(effectMode);
     }
 
     public void setEffectMode(EffectMode effectMode) {
-        this.effectMode = Optional.of(effectMode);
+        this.effectMode = effectMode;
     }
 
-    public OptionalInt getTransitionTime() {
-        return transitionTime;
+    public Optional<Integer> getTransitionTime() {
+        return Optional.ofNullable(transitionTime);
     }
 
     public void setTransitionTime(int transitionTime) {
-        this.transitionTime = OptionalInt.of(transitionTime);
+        this.transitionTime = transitionTime;
     }
 
     public Optional<Color> getColor() {
-        return color;
+        return Optional.ofNullable(color);
     }
 
     public void setColor(Color color) {
-        this.color = Optional.of(color);
+        this.color = color;
     }
 
     public enum AlertMode {

--- a/src/main/java/ch/wisv/chue/hue/PhilipsHueFacade.java
+++ b/src/main/java/ch/wisv/chue/hue/PhilipsHueFacade.java
@@ -165,7 +165,7 @@ public class PhilipsHueFacade implements HueFacade {
         PHLightState phLightState = new PHLightState();
 
         if (lightState.getTransitionTime().isPresent()) {
-            phLightState.setTransitionTime(lightState.getTransitionTime().getAsInt());
+            phLightState.setTransitionTime(lightState.getTransitionTime().get());
         }
 
         if (lightState.getAlertMode().isPresent()) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -49,12 +49,15 @@
         <p>
             <select multiple="multiple" id="selected_light_ids">
                 <option th:each="light : ${lights}"
-                        th:value="${light.id}"
-                        th:text="${light.name}"
-                        style="background: ">Light Name</option>
+                        th:id="'selected_light_' + ${light.key.id}"
+                        th:value="${light.key.id}"
+                        th:text="${light.key.name}"
+                        th:style="'background-color: ' + ${light.value}"
+                        data-color="#D3D3D3">Light Name
+                </option>
             </select>
 
-           <input id="selected_light_color" type="color" name="hex" value="#eeeeee" />
+            <input id="selected_light_color" type="color" name="hex" value="#D3D3D3"/>
         </p>
     </div>
     <div>
@@ -120,15 +123,24 @@
     var waiting = false;
 
     $("#selected_light_color").on("input", function(event) {
-         $.ajax({
-            type: "POST",
-            url: '/color',
-            data: {
-                "hex": event.currentTarget.value,
-                "id": $("#selected_light_ids").val()
-            }
-          });
+        var id = $("#selected_light_ids").val();
+        var hex = event.currentTarget.value;
+
+        $.post('color',
+                {"hex": hex, "id": id},
+                function () {
+                    id.forEach(function (value) {
+                        var option = $("#selected_light_" + value);
+                        option.css('background-color', hex);
+                        option.data('color', hex);
+                    });
+                }
+        );
     });
+
+    $("#selected_light_ids").find("option").click(function () {
+        $("#selected_light_color").val($(this).data('color'));
+    })
 </script>
 </body>
 </html>


### PR DESCRIPTION
Change the implementation of HueLightState (more of a beautyfix) to comply with the `Optional` best practices.

Add color to model in controller to keep template more clean. Otherwise, you'll have to check the `Optionals` with thymeleaf and convert the `Color` to a hexadecimal representation in the template. However, this controller implementation also feels a bit clumsy (especially the fact that it's now a `TreeMap<HueLamp, String>`).

Update JavaScript to update web interface after color change, so that you actually see the new color for the affected lamp(s). Also make the color input field change when clicking on a lamp. We can make this more clean (e.g. perform a `GET` operation to update the color input field, instead of using a data field) if we improve the API, as `GET color/1/` will now try to change the color of all lamps to `1` (i.e. conflicting endpoints).

The data field is used as a somewhat lazy solution for parsing the rgb value of background-color (`$("#selected_light_1").css("background-color")` will always return an `rgb(r,g,b)` value instead of a hexadecimal representation (exception: IE6 :joy:)).

Fixes #3.
